### PR TITLE
Add cmake to build requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=40.8.0", "wheel"]
+requires = ["cmake", "setuptools>=40.8.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.black]


### PR DESCRIPTION
It was found in CI/CD that `cmake` python package is required by the atlas4py build system.