### PR TITLE
Update eckit and ecbuild to latest versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,8 @@ HERE = os.path.abspath(os.path.dirname(__file__))
 
 VERSIONS = dict(
     cmake="3.14.0",
-    ecbuild="3.8.0",
-    eckit="1.28.0",
+    ecbuild="3.9.1",
+    eckit="1.28.6",
     atlas="0.35.1",
     pybind11="2.11.1",
     python="3.6",
@@ -135,7 +135,7 @@ class CMakeBuild(build_ext):
         )
 
 
-PACKAGE_VERSION = "0.35.1.dev15"
+PACKAGE_VERSION = "0.35.1.dev16"
 # Meaning of the version scheme "{major}.{minor}.{patch}.dev{dev}":
 #   - {major}.{minor}.{patch} => version of the atlas C++ library (hardcoded in 'setup.py')
 #   - {dev} => version of the Python bindings as the commit number in 'master'

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ HERE = os.path.abspath(os.path.dirname(__file__))
 VERSIONS = dict(
     cmake="3.14.0",
     ecbuild="3.8.0",
-    eckit="1.24.0",
+    eckit="1.28.0",
     atlas="0.35.1",
     pybind11="2.11.1",
     python="3.6",
@@ -72,7 +72,9 @@ class CMakeBuild(build_ext):
                 + ", ".join(e.name for e in self.extensions)
             )
 
-        cmake_version = LooseVersion(re.search(r"version\s*([\d.]+)", out.decode()).group(1))
+        cmake_version = LooseVersion(
+            re.search(r"version\s*([\d.]+)", out.decode()).group(1)
+        )
         if cmake_version < CMAKE_MIN_VERSION:
             raise RuntimeError(f"CMake >= {CMAKE_MIN_VERSION} is required on Windows")
 
@@ -121,12 +123,17 @@ class CMakeBuild(build_ext):
             if archs_values:
                 cmake_args.append("-DCMAKE_OSX_ARCHITECTURES=" + archs_values)
         # print(f"./{self.build_temp}$ " + " ".join(["cmake", ext.sourcedir] + cmake_args))
-        subprocess.check_call(["cmake", ext.sourcedir] + cmake_args, cwd=self.build_temp)
+        subprocess.check_call(
+            ["cmake", ext.sourcedir] + cmake_args, cwd=self.build_temp
+        )
 
         # Run CMake build
         print("-" * 10, "Building extensions", "-" * 40)
         build_args = ["--config", cfg, "-j", str(BUILD_JOBS)]
-        subprocess.check_call(["cmake", "--build", "."] + build_args, cwd=self.build_temp)
+        subprocess.check_call(
+            ["cmake", "--build", "."] + build_args, cwd=self.build_temp
+        )
+
 
 PACKAGE_VERSION = "0.35.1.dev15"
 # Meaning of the version scheme "{major}.{minor}.{patch}.dev{dev}":


### PR DESCRIPTION
These updates fix compilation with CMake 4.0.0 as our ancient versions still contained `cmake_minimum_required` versions <= 3.5 for which compatibility is dropped in CMake 4.0.0.