### PR TITLE
Fix editable installation

### DIFF
--- a/.github/actions/setup-build-env/action.yml
+++ b/.github/actions/setup-build-env/action.yml
@@ -34,14 +34,14 @@ runs:
       run: |
         sudo apt-get update
         sudo apt-get install -y --no-install-recommends \
-          build-essential cmake ninja-build libopenmpi-dev openmpi-bin libomp-dev
+          build-essential libopenmpi-dev openmpi-bin libomp-dev
 
     - name: Install system build dependencies (macOS)
       if: runner.os == 'macOS'
       shell: bash
       run: |
         brew update
-        brew install cmake ninja open-mpi
+        brew install open-mpi
 
     - name: Collect system library versions for cache key
       id: sys-deps-key

--- a/.github/actions/setup-build-env/action.yml
+++ b/.github/actions/setup-build-env/action.yml
@@ -1,0 +1,66 @@
+name: Setup atlas4py build environment
+description: Install system + Python build dependencies for atlas4py on Linux/macOS.
+
+inputs:
+  python-version:
+    description: Python version to set up
+    required: true
+  install-build-backend:
+    description: >
+      Whether to pre-install pybind11, scikit-build-core and numpy into the
+      host environment. Required for `--no-build-isolation` builds; can be
+      skipped when pip provisions an isolated build environment.
+    required: false
+    default: 'false'
+
+outputs:
+  sys-deps-cache-key:
+    description: >-
+      A string encoding the versions of installed system libraries (e.g. MPI).
+      Include this in cache keys that depend on compiled system dependencies.
+    value: ${{ steps.sys-deps-key.outputs.value }}
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Python ${{ inputs.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Install system build dependencies (Linux)
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends \
+          build-essential cmake ninja-build libopenmpi-dev openmpi-bin libomp-dev
+
+    - name: Install system build dependencies (macOS)
+      if: runner.os == 'macOS'
+      shell: bash
+      run: |
+        brew update
+        brew install cmake ninja open-mpi
+
+    - name: Collect system library versions for cache key
+      id: sys-deps-key
+      shell: bash
+      run: |
+        if [ "$RUNNER_OS" = "Linux" ]; then
+          MPI_VERSION=$(dpkg-query --showformat='${Version}' --show libopenmpi-dev)
+          OMP_VERSION=$(dpkg-query --showformat='${Version}' --show libomp-dev)
+          echo "value=mpi-${MPI_VERSION}-omp-${OMP_VERSION}" >> "$GITHUB_OUTPUT"
+        else
+          MPI_VERSION=$(brew list --versions open-mpi | awk '{print $2}')
+          echo "value=mpi-${MPI_VERSION}" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Upgrade pip
+      shell: bash
+      run: python -m pip install --upgrade pip
+
+    - name: Install Python build backend (for --no-build-isolation builds)
+      if: inputs.install-build-backend == 'true'
+      shell: bash
+      run: python -m pip install pybind11 scikit-build-core numpy

--- a/.github/actions/setup-build-env/action.yml
+++ b/.github/actions/setup-build-env/action.yml
@@ -24,7 +24,7 @@ runs:
   using: composite
   steps:
     - name: Set up Python ${{ inputs.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ inputs.python-version }}
 

--- a/.github/actions/verify-atlas4py-rebuild/action.yml
+++ b/.github/actions/verify-atlas4py-rebuild/action.yml
@@ -1,0 +1,39 @@
+name: Verify atlas4py editable rebuild
+description: >
+  Verify that an editable install of atlas4py picks up edits to both Python
+  and C++ sources (i.e. that scikit-build-core's editable.rebuild works).
+
+runs:
+  using: composite
+  steps:
+    - name: Verify editable Python edits are picked up
+      shell: bash
+      run: |
+        python - <<'PY'
+        import pathlib
+        path = pathlib.Path("src/atlas4py/__init__.py")
+        marker = "\n__CI_EDITABLE_MARKER__ = 'changed'\n"
+        txt = path.read_text(encoding="utf-8")
+        if marker not in txt:
+            path.write_text(txt + marker, encoding="utf-8")
+        import atlas4py
+        assert getattr(atlas4py, "__CI_EDITABLE_MARKER__", None) == "changed"
+        print("Editable Python change reflected OK")
+        PY
+
+    - name: Verify editable C++ edits trigger a rebuild
+      shell: bash
+      run: |
+        sed -i.bak 's/ATLAS4PY_VERSION_STRING/__CI_EDITABLE_MARKER__/g' \
+          src/atlas4py/_atlas4py.cpp && rm -f src/atlas4py/_atlas4py.cpp.bak
+        python - <<'PY'
+        import atlas4py
+        assert atlas4py.__version__ == "__CI_EDITABLE_MARKER__", atlas4py.__version__
+        print("Editable C++ change reflected OK")
+        PY
+
+    - name: Restore edited sources
+      if: always()
+      shell: bash
+      run: |
+        git checkout -- src/atlas4py/__init__.py src/atlas4py/_atlas4py.cpp || true

--- a/.github/actions/verify-atlas4py/action.yml
+++ b/.github/actions/verify-atlas4py/action.yml
@@ -1,0 +1,27 @@
+name: Verify atlas4py installation
+description: Common smoke tests run after an atlas4py install (import, version, pytest).
+
+runs:
+  using: composite
+  steps:
+    - name: Verify import
+      shell: bash
+      env:
+        ATLAS_DEBUG: "1"
+      run: python -c "import atlas4py; print('atlas4py', atlas4py.__version__, 'imported successfully')"
+
+    - name: Verify version matches pyproject.toml
+      shell: bash
+      run: |
+        python - <<'PY'
+        import tomllib, pathlib, atlas4py
+        expected = tomllib.loads(pathlib.Path("pyproject.toml").read_text())["project"]["version"]
+        assert atlas4py.__version__ == expected, (atlas4py.__version__, expected)
+        print("Version OK:", expected)
+        PY
+
+    - name: Run pytest suite
+      shell: bash
+      run: |
+        python -m pip install pytest
+        pytest -v tests

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -1,11 +1,18 @@
 name: Build and deploy wheel
 
 on:
+  # Trigger the workflow on all pushes, except on tag creation
   push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+    branches:
+    - '**'
+    tags-ignore:
+    - '**'
 
+  # Trigger the workflow on all pull requests
+  pull_request: ~
+
+  # Allow workflow to be dispatched on demand
+  workflow_dispatch: ~
 jobs:
   build_wheels:
     name: Build wheels on ${{ matrix.os }} for ${{ matrix.python }}
@@ -67,6 +74,10 @@ jobs:
     name: Upload wheels to TestPyPI
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
+
+    # Only run for pushes to master (not PRs, not workflow_dispatch)
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+
     steps:
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -14,9 +14,16 @@ on:
   # Allow workflow to be dispatched on demand
   workflow_dispatch: ~
 jobs:
+  pre-check:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Condition met, proceeding with workflow."
+
   build_wheels:
     name: Build wheels on ${{ matrix.os }} for ${{ matrix.python }}
     runs-on: ${{ matrix.os }}
+    needs: pre-check # This job won't start if 'pre-check' is skipped
     strategy:
       matrix:
         os:
@@ -56,6 +63,7 @@ jobs:
   build_sdist:
     name: Build sdist
     runs-on: ubuntu-latest
+    needs: pre-check # This job won't start if 'pre-check' is skipped
     steps:
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -48,7 +48,7 @@ jobs:
           CIBW_TEST_REQUIRES: -r requirements-dev.txt
           CIBW_TEST_COMMAND: pytest -v {project}/tests
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wheel-${{matrix.python}}-${{ matrix.os }}
           path: ./dist/*.whl
@@ -58,14 +58,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Python
-        uses: actions/setup-python@v2
-      - uses: actions/checkout@v4
+        uses: actions/setup-python@v6
+      - uses: actions/checkout@v6
       - name: Install requirements
         run: python -m pip install -r requirements-dev.txt
       - name: Make sdist
         run:  python -m build --sdist --outdir dist/
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: sdist
           path: ./dist/*.tar.gz
@@ -79,7 +79,7 @@ jobs:
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
 
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           path: dist
           merge-multiple: true

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -67,6 +67,8 @@ jobs:
     steps:
       - name: Set up Python
         uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
       - uses: actions/checkout@v6
       - name: Install requirements
         run: python -m pip install -r requirements-dev.txt

--- a/.github/workflows/editable-install.yml
+++ b/.github/workflows/editable-install.yml
@@ -1,0 +1,173 @@
+name: Editable install tests
+
+on:
+  push:
+    branches:
+      - '**'
+    tags-ignore:
+      - '**'
+  pull_request: ~
+  workflow_dispatch: ~
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # Editable install using the bundled (FetchContent) eckit + atlas dependencies
+  # ---------------------------------------------------------------------------
+  editable-internal:
+    name: Editable (bundled) - ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        python-version: ["3.13"]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup build environment
+        uses: ./.github/actions/setup-build-env
+        with:
+          python-version: ${{ matrix.python-version }}
+          # Pre-install build backend only when we will skip pip's build isolation.
+          install-build-backend: 'true'
+
+      - name: Editable install
+        run: |
+            export CMAKE_ARGS="-DATLAS_ENABLE_OMP=ON"
+            python -m pip install --no-build-isolation -v -e .
+
+      # ----- Verification --------------------------------------------------
+      - name: Verify atlas4py installation
+        uses: ./.github/actions/verify-atlas4py
+
+      # ----- Editable-rebuild specific checks ------------------------------
+      - name: Verify atlas4py editable rebuild
+        uses: ./.github/actions/verify-atlas4py-rebuild
+
+  # ---------------------------------------------------------------------------
+  # Editable install using externally built eckit + atlas
+  # ---------------------------------------------------------------------------
+  editable-external:
+    name: Editable (external) - ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        python-version: ["3.13"]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup build environment
+        uses: ./.github/actions/setup-build-env
+        id: build-env
+        with:
+          python-version: ${{ matrix.python-version }}
+          install-build-backend: 'true'
+
+      - name: Extract pinned dependency versions from pyproject.toml
+        id: versions
+        run: |
+          python - <<'PY' >> "$GITHUB_ENV"
+          import pathlib, re, tomllib
+          cfg = tomllib.loads(pathlib.Path("pyproject.toml").read_text())
+          args = cfg["tool"]["scikit-build"]["cmake"]["args"]
+          pat = re.compile(r"^-D(ATLAS4PY_[A-Za-z0-9_]+)=(.*)$")
+          for a in args:
+              m = pat.match(a)
+              if m:
+                  print(f"{m.group(1)}={m.group(2)}")
+          PY
+
+      - name: Cache external eckit + atlas install
+        id: cache-deps
+        uses: actions/cache@v4
+        with:
+          path: deps/install
+          key: ext-deps-atlas-${{ env.ATLAS4PY_ATLAS_VERSION }}-eckit-${{ env.ATLAS4PY_ECKIT_VERSION }}-ecbuild-${{ env.ATLAS4PY_ECBUILD_VERSION }}-${{ runner.os }}[${{ steps.build-env.outputs.sys-deps-cache-key }}]
+
+      - name: Build external eckit + atlas
+        if: steps.cache-deps.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p deps/source
+          pushd deps
+
+          echo "::group::Clone ecbuild ${ATLAS4PY_ECBUILD_VERSION}"
+          git clone --branch ${ATLAS4PY_ECBUILD_VERSION} --single-branch https://github.com/ecmwf/ecbuild source/ecbuild
+          echo "::endgroup::"
+
+          echo "::group::Clone eckit ${ATLAS4PY_ECKIT_VERSION}"
+          git clone --branch ${ATLAS4PY_ECKIT_VERSION}   --single-branch https://github.com/ecmwf/eckit   source/eckit
+          echo "::endgroup::"
+
+          echo "::group::Clone atlas ${ATLAS4PY_ATLAS_VERSION}"
+          git clone --branch ${ATLAS4PY_ATLAS_VERSION}   --single-branch https://github.com/ecmwf/atlas   source/atlas
+          echo "::endgroup::"
+
+          export CMAKE_PREFIX_PATH=$PWD/install
+
+          echo "::group::Configure eckit"
+          cmake -S source/eckit -B build/eckit -G Ninja \
+            -DENABLE_TESTS=OFF -DENABLE_FORTRAN=OFF -DCMAKE_BUILD_TYPE=Release
+          echo "::endgroup::"
+
+          echo "::group::Build eckit"
+          cmake --build build/eckit --parallel
+          echo "::endgroup::"
+
+          echo "::group::Install eckit"
+          cmake --install build/eckit --prefix install/eckit
+          echo "::endgroup::"
+
+          echo "::group::Configure atlas"
+          cmake -S source/atlas -B build/atlas -G Ninja \
+            -DENABLE_TESTS=OFF -DENABLE_FORTRAN=OFF -DCMAKE_BUILD_TYPE=Release
+          echo "::endgroup::"
+
+          echo "::group::Build atlas"
+          cmake --build build/atlas --parallel
+          echo "::endgroup::"
+
+          echo "::group::Install atlas"
+          cmake --install build/atlas --prefix install/atlas
+          echo "::endgroup::"
+
+          popd
+
+      - name: Editable install against external deps
+        run: |
+          export CMAKE_PREFIX_PATH=$PWD/deps/install
+          python -m pip install --no-build-isolation -v -e .
+
+      # ----- Verification --------------------------------------------------
+      - name: Verify atlas4py installation
+        uses: ./.github/actions/verify-atlas4py
+
+      # ----- External-deps specific check ----------------------------------
+      - name: Verify atlas4py was linked against the external atlas
+        run: |
+          python - <<'PY'
+          import pathlib, platform, subprocess, atlas4py._atlas4py as _ext
+          ext = pathlib.Path(_ext.__file__).resolve()
+          print(ext)
+          if platform.system() == "Darwin":
+              # `otool -l` dumps load commands, including LC_RPATH entries which
+              # carry the absolute external install path baked in at link time.
+              out = subprocess.check_output(["otool", "-l", str(ext)]).decode()
+          else:
+              out = subprocess.check_output(["ldd", str(ext)]).decode()
+          print(out)
+          assert "libatlas" in out, "libatlas not linked"
+          # Must resolve to our externally-installed atlas
+          external = str(pathlib.Path("deps/install/atlas").resolve())
+          assert external in out, f"expected external atlas path {external} in linker output"
+          print("External atlas linkage OK")
+          PY
+
+      # ----- Editable-rebuild specific checks ------------------------------
+      - name: Verify atlas4py editable rebuild
+        uses: ./.github/actions/verify-atlas4py-rebuild

--- a/.github/workflows/editable-install.yml
+++ b/.github/workflows/editable-install.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup build environment
         uses: ./.github/actions/setup-build-env
@@ -60,7 +60,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup build environment
         uses: ./.github/actions/setup-build-env
@@ -85,7 +85,7 @@ jobs:
 
       - name: Cache external eckit + atlas install
         id: cache-deps
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: deps/install
           key: ext-deps-atlas-${{ env.ATLAS4PY_ATLAS_VERSION }}-eckit-${{ env.ATLAS4PY_ECKIT_VERSION }}-ecbuild-${{ env.ATLAS4PY_ECBUILD_VERSION }}-${{ runner.os }}[${{ steps.build-env.outputs.sys-deps-cache-key }}]

--- a/.github/workflows/editable-install.yml
+++ b/.github/workflows/editable-install.yml
@@ -14,6 +14,7 @@ jobs:
   # Editable install using the bundled (FetchContent) eckit + atlas dependencies
   # ---------------------------------------------------------------------------
   editable-internal:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     name: Editable (bundled) - ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -50,6 +51,7 @@ jobs:
   # Editable install using externally built eckit + atlas
   # ---------------------------------------------------------------------------
   editable-external:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     name: Editable (external) - ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -1,10 +1,19 @@
 name: Tox tests
 
 on:
+
+  # Trigger the workflow on all pushes, except on tag creation
   push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+    branches:
+    - '**'
+    tags-ignore:
+    - '**'
+
+  # Trigger the workflow on all pull requests
+  pull_request: ~
+
+  # Allow workflow to be dispatched on demand
+  workflow_dispatch: ~
 
 jobs:
   build:

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -18,6 +18,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -30,7 +30,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install python dependencies
       run: |
-        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install --upgrade pip
     - name: Test with tox
       run: |
         pyversion_no_dot="${{ matrix.python-version }}"

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -23,9 +23,9 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install python dependencies

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -18,6 +18,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    # since we trigger on all branches, we get two events for a pull request on the same repo
+    #  so skip PR runs in that case
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     strategy:
       matrix:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,8 +53,16 @@ cmake.args = [
 ]
 wheel.expand-macos-universal-tags = true
 wheel.install-dir = "atlas4py"
-wheel.packages = []
-wheel.license-files = []
+wheel.packages = ["src/atlas4py"]
+wheel.exclude = ["**/CMakeLists.txt", "**/*.cmake", "**/*.cpp", "**/*.hpp"]
+wheel.license-files = ["LICENSE"]
+
+editable.rebuild = true       # automatically recompile/install if needed
+editable.verbose = true       # verbose output
+
+[[tool.scikit-build.overrides]]
+if.state = "editable"
+cmake.build-type = "Debug"
 
 [tool.black]
 line-length = 99

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,14 +2,12 @@
 build-backend = 'scikit_build_core.build'
 requires = [
     'scikit-build-core>=0.10.7',
-    'wheel>=0.45.1',
     'pybind11>=2.11.1',
 ]
 
 [project]
 dependencies = [
-  'numpy>=1.23',
-  'packaging>=20.0'
+  'numpy>=1.23'
 ]
 
 description = 'Python bindings for Atlas: a ECMWF library for parallel data-structures'
@@ -37,7 +35,7 @@ classifiers = [
 repository = 'https://github.com/GridTools/atlas4py'
 
 [project.optional-dependencies]
-test = ['pytest', 'pytest-cache']
+test = ['pytest']
 
 [tool.scikit-build]
 minimum-version = '0.5'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
 
 description = 'Python bindings for Atlas: a ECMWF library for parallel data-structures'
 name = 'atlas4py'
-version = '0.41.1.dev2' # <major>.<minor>.<patch>.dev<dev> : <atlas.major>.<atlas.minor>.<atlas.patch>.dev<atlas4py.dev>
+version = '0.41.1.dev3' # <major>.<minor>.<patch>.dev<dev> : <atlas.major>.<atlas.minor>.<atlas.patch>.dev<atlas4py.dev>
 license = {text = "Apache License 2.0"}
 readme = {file = 'README.md', content-type = 'text/markdown'}
 authors = [{email = 'willem.deconinck@ecmwf.int'}, {name = 'Willem Deconinck'}]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,5 +3,4 @@ bump-my-version>=1.2.6
 numpy>=1.17
 pytest>=6.1
 tox>=4.0
-setuptools>=69
 build>=1.2.2

--- a/src/atlas4py/CMakeLists.txt
+++ b/src/atlas4py/CMakeLists.txt
@@ -81,7 +81,3 @@ target_compile_definitions(_atlas4py PRIVATE ATLAS4PY_VERSION_STRING=${PROJECT_V
 ### Installation
 
 install(TARGETS _atlas4py DESTINATION .)
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/
-    DESTINATION .
-    FILES_MATCHING PATTERN "*.py"
-)


### PR DESCRIPTION
This PR 
- fixes editable installs and adds a CI for this.
- contains further tweaks to remove unused packages
- allows CI for all branches and PRs, but limits the upload to TestPyPi to be enabled only on push to master.

**GitHub Actions and Workflow Improvements:**

* Added three new composite GitHub Actions: `setup-build-env` (installs system and Python build dependencies, outputs cache keys), `verify-atlas4py` (smoke tests for install, version, and pytest), and `verify-atlas4py-rebuild` (checks that editable Python and C++ changes are picked up and restored). These actions are reusable across workflows and improve CI reliability and maintainability. [[1]](diffhunk://#diff-1d3c7d7b6fa33e2b341c9af1423b0cd7b3ad0027724c31dbff7c3efc24c46043R1-R66) [[2]](diffhunk://#diff-e442bccf1c7feed0ab70e3b3201b0dbd3a82cf827647f01ef1276517a287e94fR1-R27) [[3]](diffhunk://#diff-664f2ef7c32fb8232cd8afb7028a3d739a2027b122a7a33fc30838c823424c9dR1-R39)

* Introduced a new workflow, `editable-install.yml`, to test editable installs of `atlas4py` both with bundled and externally built dependencies, including cache usage for external builds and verification of correct linkage. This ensures robust support for developer workflows and downstream integration.

**Packaging and Build System Updates:**

* Updated `pyproject.toml` to:
  - Enable `scikit-build-core`'s editable rebuild functionality and verbose output.
  - Explicitly specify included packages and excluded files for wheel builds, ensuring only necessary files are packaged.
  - Add license file inclusion and set wheel metadata correctly.
  - Set editable installs to use Debug build type for easier development.
  - Remove now-unnecessary dependencies (`wheel`, `packaging`, `pytest-cache`) from required and test dependencies. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L5-R15) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L40-R38) [[3]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L56-R63)

* Removed installation of Python files via CMake, as packaging is now handled by `scikit-build-core` configuration.

**Workflow Triggers and Test Matrix:**

* Updated workflow triggers in `tox.yml` and `cibuildwheel.yml` to run on all branches and pull requests (excluding tags), and enabled manual dispatch. This ensures CI runs for all contributions and scenarios. [[1]](diffhunk://#diff-8a1944567ec5d9e12aaaac28489c47e6567e13b58d861815379f9b8d3aeb2623R4-R16) [[2]](diffhunk://#diff-504e739c530d50b780e9a09ae8fd0c3ea8258ea7553be06afb06f03f95b1ee0aR4-R15)

* Limited TestPyPI upload to pushes on `master` only, avoiding uploads for pull requests or manual runs.

**Dependency Management:**

* Removed redundant dependencies from `requirements-dev.txt` and the CI setup steps, streamlining the build and test environments. [[1]](diffhunk://#diff-2b4945591edfeaa4cf4d3f155e66d4b43d1bda7a55d881d5cf3107f1b05abbbcL6) [[2]](diffhunk://#diff-8a1944567ec5d9e12aaaac28489c47e6567e13b58d861815379f9b8d3aeb2623L24-R33)

---

**References:**
- [[1]](diffhunk://#diff-1d3c7d7b6fa33e2b341c9af1423b0cd7b3ad0027724c31dbff7c3efc24c46043R1-R66) [[2]](diffhunk://#diff-e442bccf1c7feed0ab70e3b3201b0dbd3a82cf827647f01ef1276517a287e94fR1-R27) [[3]](diffhunk://#diff-664f2ef7c32fb8232cd8afb7028a3d739a2027b122a7a33fc30838c823424c9dR1-R39) [[4]](diffhunk://#diff-d8bee5ee112e1abb5673b93dde4a793a07a74034c99bb99f8d6aff64fe9d1dd3R1-R173) [[5]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L5-R15) [[6]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L40-R38) [[7]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L56-R63) [[8]](diffhunk://#diff-0df556642788ae3cca4440632a650fb2c0333c864f8aa5117d12ee214c444b87L84-L87) [[9]](diffhunk://#diff-8a1944567ec5d9e12aaaac28489c47e6567e13b58d861815379f9b8d3aeb2623R4-R16) [[10]](diffhunk://#diff-504e739c530d50b780e9a09ae8fd0c3ea8258ea7553be06afb06f03f95b1ee0aR4-R15) [[11]](diffhunk://#diff-504e739c530d50b780e9a09ae8fd0c3ea8258ea7553be06afb06f03f95b1ee0aR77-R80) [[12]](diffhunk://#diff-2b4945591edfeaa4cf4d3f155e66d4b43d1bda7a55d881d5cf3107f1b05abbbcL6) [[13]](diffhunk://#diff-8a1944567ec5d9e12aaaac28489c47e6567e13b58d861815379f9b8d3aeb2623L24-R33)